### PR TITLE
Fix prefix maximum length

### DIFF
--- a/src/html/validate.html
+++ b/src/html/validate.html
@@ -11,7 +11,7 @@
       <legend>Validate IP prefix : Origin AS</legend>
       <form method="post" action="http://localhost:5000/validator/api/v1">
         <label for="prefix">IP prefix</label>
-        <input type="text" id="prefix" name="prefix" maxlength="18" size="30"/>
+        <input type="text" id="prefix" name="prefix" maxlength="43" size="30"/>
         <br/>
         <label for="asn">Origin AS</label>
         <input type="text" id="asn" name="asn" maxlength="10" size="30"/>


### PR DESCRIPTION
18 is a too short to enter an IPv6 prefix (ie. 2001:db8:ffff:ff00:/56 is longer than 18 chars)